### PR TITLE
add intake catalog to read soil data from s3

### DIFF
--- a/data/catalog.yml
+++ b/data/catalog.yml
@@ -1,0 +1,71 @@
+plugins:
+  source:
+    - module: intake_xarray
+sources:
+  soil:
+    name: 'SOIL'
+    description: 'Default soil data for ldndctools (site file generation)'
+    driver: netcdf
+    parameters:
+      res:
+        default: 'LR'
+        allowed: ['LR', 'MR', 'HR']
+        description: 'Resolution (LR, MR or HR).'
+        type: str
+    args:
+      urlpath: 'simplecache::s3://ldndcdata/GLOBAL_WISESOIL_S1_{{res}}.nc'
+      storage_options:
+        s3:
+          anon: true
+          default_fill_cache: false
+          client_kwargs:
+            endpoint_url: 'https://s3.imk-ifu.kit.edu:8082'
+        simplecache:
+          cache_storage: '.cache'
+          same_names: true
+
+      chunks: {}
+      xarray_kwargs:
+        decode_times: false
+        engine: h5netcdf
+
+    metadata:
+      source: 'ISRIC-WISE Global Soil Database v3'
+      plot:
+          kind: 'image'
+          x: 'lon'
+          y: 'lat'
+          z: 'TOTC'
+          label: 'Total C [g cm-3]'
+          title: 'Sample plot'
+          clim: !!python/tuple [0, 500]
+          cmap: 'YlOrBr'
+          geo: true
+          logz: true
+          grid: true
+          coastline: '50m'
+          rasterize: true
+
+
+  climate_pgf3:
+    name: 'CLIMATE'
+    description: 'Princeton Global Fields 0.25x0.25 deg res daily data for ldndctools (climate file generation). Careful, VERY BIG!'
+    driver: netcdf
+    parameters:
+      year:
+        default: 2016
+        min: 1985
+        max: 2016
+        description: 'Year of daily climate data'
+        type: int
+    args:
+      urlpath: 'simplecache::s3://ldndcdata/climate/pgf3/pgf_025deg_v3_{{year}}.nc'
+      storage_options:
+        s3:
+          anon: true
+          default_fill_cache: false
+          client_kwargs:
+            endpoint_url: 'https://s3.imk-ifu.kit.edu:8082'
+        simplecache:
+          cache_storage: '.cache'
+          same_names: true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,9 @@
-netCDF4
+netcdf4
 numpy
+intake
+intake-xarray
+s3fs
+h5netcdf
 pandas
 pyyaml
 progressbar

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,9 @@ setup(
     packages=find_packages(exclude=["docs", "tests"]),
     install_requires=INSTALL_REQUIRES,
     package_dir={"ldndctools": "ldndctools"},
-    package_data={"ldndctools": ["data/misc", "data/soil", "data/tmworld"]},
+    package_data={
+        "ldndctools": ["data/catalog.yml", "data/misc", "data/soil", "data/tmworld"]
+    },
     include_package_data=True,
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
This adds a first intake catalog to read soil and climate data from a public s3 bucket.

Needs further polishing, but works for soil data.

TODOs:
- use global intake cache dir
- convert climate netcdfs to Zarr format for lighter access
- add other data files to s3
- cleanup resource access (setup.py and files)