### PR TITLE
Add a dockerfile for running the streamlit app

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+tests
+.remove
+.vscode
+assets
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+# syntax=docker/dockerfile:1.3
+FROM ubuntu:latest
+EXPOSE 8501
+WORKDIR /app
+RUN mkdir /usr/src/app
+COPY requirements.txt /usr/src/app/
+RUN apt-get update                                      && \
+    apt-get install software-properties-common -y       && \ 
+    apt-add-repository ppa:ubuntugis/ubuntugis-unstable && \
+    apt-get update && \
+    apt-get install git curl python3 python3-pip gdal-bin libgdal-dev -y && \ 
+    python3 -m pip install --upgrade pip                 && \
+    python3 -m pip install GDAL==3.4.1                   && \  
+    python3 -m pip install -r /usr/src/app/requirements.txt                       
+COPY . /usr/src/app
+RUN python3 -m pip install -e /usr/src/app
+WORKDIR /usr/src/app
+ENV PYTHONPATH "/usr/src/app:${PYTHONPATH}"
+CMD ["dlsc", "--gui"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+NAME   := cwerner/ldndctools
+TAG    := $$(git log -1 --pretty=%h)
+IMG    := ${NAME}:${TAG}
+LATEST := ${NAME}:latest
+ 
+export DOCKER_BUILDKIT := 1
+export $(xargs < .env)
+
+build:
+	@echo ${TAG}
+	@docker build -t ${IMG} .
+	@docker tag ${IMG} ${LATEST}
+ 
+push:
+	@docker push ${NAME}
+
+run:
+	@docker run --rm -p 8501:8501 --env-file .env ${LATEST} 
+
+login:
+	@docker log -u ${DOCKER_USER} -p ${DOCKER_PASS}

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ numpy >= 1.21.5
 pandas >= 1.3.5
 pydantic >= 1.9.0
 pygeos >= 0.12.0
+python-dotenv >= 0.19.2
 questionary >= 1.10.0
 rioxarray >= 0.9.1
 s3fs >= 0.4.2


### PR DESCRIPTION
This PR adds a dockerfile that runs `dlsc --gui` and exposes the GUI at port 8501.

Features:
- adds dockerfile
- adds a makefile to build, push and run the dockerfile
- change the code to source default AWS env vars or a local `.env` file
- the datasets are uploaded to S3 using a resigned url (that expires)

Closes #39 